### PR TITLE
moves functor arguments to first position

### DIFF
--- a/src/schemes.js
+++ b/src/schemes.js
@@ -12,11 +12,11 @@ import { In, out } from "./Fix";
 
 export type Algebra<F, A> = HKT<F, A> => A;
 
-export function cata<F, A>(transformer: Algebra<F, A>,
-                           term: Fix<F>,
-                           functor: Functor<F>) : A {
+export function cata<F, A>(functor: Functor<F>,
+                           transformer: Algebra<F, A>,
+                           term: Fix<F>) : A {
   const extracted = out(term),
-        childrenMapped = functor.map(x => cata(transformer, x, functor), extracted),
+        childrenMapped = functor.map(x => cata(functor, transformer, x), extracted),
         transformed = transformer(childrenMapped);
 
   return transformed;
@@ -25,11 +25,11 @@ export const catamorphism = cata;
 
 export type Coalgebra<F, A> = A => HKT<F, A>;
 
-export function ana<F, A>(transformer: Coalgebra<F, A>,
-                          seed: A,
-                          functor: Functor<F>) : Fix<F> {
+export function ana<F, A>(functor: Functor<F>,
+                          transformer: Coalgebra<F, A>,
+                          seed: A) : Fix<F> {
   const transformed = transformer(seed),
-        childrenMapped = functor.map(x => ana(transformer, x, functor), transformed),
+        childrenMapped = functor.map(x => ana(functor, transformer, x), transformed),
         rewrapped = new In(childrenMapped);
 
   return rewrapped;
@@ -37,11 +37,11 @@ export function ana<F, A>(transformer: Coalgebra<F, A>,
 export const anamorphism = ana;
 
 export type RAlgebra<F, A> = (Fix<F>, HKT<F, A>) => A;
-export function para<F, A>(transformer: RAlgebra<F, A>,
-                           term: Fix<F>,
-                           functor: Functor<F>) : A {
+export function para<F, A>(functor: Functor<F>,
+                           transformer: RAlgebra<F, A>,
+                           term: Fix<F>) : A {
   const extracted = out(term),
-        childrenMapped = functor.map(x => para(transformer, x, functor), extracted),
+        childrenMapped = functor.map(x => para(functor, transformer, x), extracted),
         transformed = transformer(term, childrenMapped);
 
   return transformed;
@@ -53,14 +53,14 @@ function id<A>(a: A) : A {
 }
 
 export type RCoalgebra<F, A> = A => HKT<F, Either<Fix<F>, A>>;
-export function apo<F, A>(transformer: RCoalgebra<F, A>,
-                          seed: A,
-                          functor: Functor<F>) : Fix<F> {
+export function apo<F, A>(functor: Functor<F>,
+                          transformer: RCoalgebra<F, A>,
+                          seed: A) : Fix<F> {
 
   const transformed : HKT<F, Either<Fix<F>, A>> = transformer(seed);
 
   function fanIn(e: Either<Fix<F>, A>) : Fix<F> {
-    return either(id, x => apo(transformer, x, functor), e);
+    return either(id, x => apo(functor, transformer, x), e);
   }
 
   const childrenMapped : HKT<F, Fix<F>> = functor.map(fanIn, transformed);
@@ -68,21 +68,21 @@ export function apo<F, A>(transformer: RCoalgebra<F, A>,
 }
 export const apomorphism = apo;
 
-export function hylo<F, A, B>(tearDown: Algebra<F, B>,
+export function hylo<F, A, B>(functor: Functor<F>,
+                              tearDown: Algebra<F, B>,
                               buildUp: Coalgebra<F, A>,
-                              seed: A,
-                              functor: Functor<F>) : B {
+                              seed: A) : B {
   const built : HKT<F, A> = buildUp(seed),
-        recursed : HKT<F, B> = functor.map((x : A) => hylo(tearDown, buildUp, x, functor), built),
+        recursed : HKT<F, B> = functor.map((x : A) => hylo(functor, tearDown, buildUp, x), built),
         flattened : B = tearDown(recursed);
 
   return flattened;
 }
 export const hylomorphism = hylo;
 
-function zygoAlgebra<F, A, B>(alg: Algebra<F, B>,
-                              almostAlgebra: (HKT<F, [A, B]>) => A,
-                              functor: Functor<F>) : Algebra<F, [A, B]> {
+function zygoAlgebra<F, A, B>(functor: Functor<F>,
+                              alg: Algebra<F, B>,
+                              almostAlgebra: (HKT<F, [A, B]>) => A) : Algebra<F, [A, B]> {
   return function(wrappedPair: HKT<F, [A, B]>) : [A, B] {
     const secondWrapped : HKT<F, B> = functor.map(pair => pair[1], wrappedPair),
           secondReduced : B = alg(secondWrapped),
@@ -92,23 +92,23 @@ function zygoAlgebra<F, A, B>(alg: Algebra<F, B>,
   };
 }
 
-export function zygo<F, A, B>(tearDown: Algebra<F, B>,
+export function zygo<F, A, B>(functor: Functor<F>,
+                              tearDown: Algebra<F, B>,
                               coalesce: (HKT<F, [A, B]>) => A,
-                              term: Fix<F>,
-                              functor: Functor<F>) : A {
-  return cata(zygoAlgebra(tearDown, coalesce, functor), term, functor)[0];
+                              term: Fix<F>) : A {
+  return cata(functor, zygoAlgebra(functor, tearDown, coalesce), term)[0];
 };
 export const zygomorphism = zygo;
 
-export function gApo<F, A, B>(expand: Coalgebra<F, B>,
+export function gApo<F, A, B>(functor: Functor<F>,
+                              expand: Coalgebra<F, B>,
                               expandA: A => HKT<F, Either<A, B>>,
-                              seed: A,
-                              functor: Functor<F>) : Fix<F> {
+                              seed: A) : Fix<F> {
 
   const expanded : HKT<F, Either<A, B>> = expandA(seed);
 
   function fanIn(e: Either<A, B>) : Fix<F> {
-    return either(a => gApo(expand, expandA, a, functor), b => ana(expand, b, functor), e);
+    return either(a => gApo(functor, expand, expandA, a), b => ana(functor, expand, b), e);
   }
 
   const transformed : HKT<F, Fix<F>> = functor.map(fanIn, expanded);
@@ -118,29 +118,29 @@ export const generalizedApomorphism = gApo;
 
 export type NaturalTransformation<F, A> = (HKT<F, A>) => HKT<F, A>;
 
-export function prepro<F, A>(naturalTransformer: NaturalTransformation<F, A>,
+export function prepro<F, A>(functor: Functor<F>,
+                             naturalTransformer: NaturalTransformation<F, A>,
                              transformer: Algebra<F, A>,
-                             term: Fix<F>,
-                             functor: Functor<F>) : A {
+                             term: Fix<F>) : A {
   const extracted : HKT<F, Fix<F>> = out(term),
-        childrenMapped : HKT<F, A> = functor.map(
-                               x => prepro(naturalTransformer, transformer, x, functor),
-                               extracted),
-        childrenMappedTransformed = naturalTransformer(childrenMapped),
-        transformed : A = transformer(childrenMappedTransformed);
+  childrenMapped : HKT<F, A> = functor.map(
+                         x => prepro(functor, naturalTransformer, transformer, x),
+                         extracted),
+  childrenMappedTransformed = naturalTransformer(childrenMapped),
+  transformed : A = transformer(childrenMappedTransformed);
 
   return transformed;
 }
 export const prepromorphism = prepro;
 
-export function postpro<F, A>(naturalTransformer: NaturalTransformation<F, A>,
+export function postpro<F, A>(functor: Functor<F>,
+                              naturalTransformer: NaturalTransformation<F, A>,
                               expand: Coalgebra<F, A>,
-                              seed: A,
-                              functor: Functor<F>) : Fix<F> {
+                              seed: A) : Fix<F> {
   const expanded : HKT<F, A> = expand(seed),
         naturalTransformed : HKT<F, A> = naturalTransformer(expanded),
         childrenMapped = functor.map(
-          x => postpro(naturalTransformer, expand, x, functor),
+          x => postpro(functor, naturalTransformer, expand, x),
           naturalTransformed),
         rewrapped = new In(childrenMapped);
 

--- a/test/cata.tests.js
+++ b/test/cata.tests.js
@@ -28,7 +28,7 @@ describe('catamorphism', () => {
       : /* ex is a Num     */ ex.value);
     }
 
-    const evalExpr : Expr => number = ex => cata(_evalExpr, ex, exprFunctor);
+    const evalExpr : Expr => number = ex => cata(exprFunctor, _evalExpr, ex);
 
 
     // AST for 2 * (1 + 1) * 4 * 3


### PR DESCRIPTION
This way, if you curry cata and ana, they become functions for lifting a function on a functor onto a function on that functor's fixed point